### PR TITLE
Fixed some bugs concerning the use in word/html docs:

### DIFF
--- a/R/des.print.R
+++ b/R/des.print.R
@@ -391,14 +391,16 @@ des.print <- function(dat, group, create = "pdf", file, index = T, fsize = 11,
         col_keys = jet$col_keys,
         tab = tab.caption,
         what = names.erg,
-        measure  =header
+        measure  =header,
+        stringsAsFactors = F
       )
     } else {
       head <- data.frame(
         col_keys = jet$col_keys,
         tab = tab.caption,
         what = c(names.erg, ""),
-        measure = c(header, "")
+        measure = c(header, ""),
+        stringsAsFactors = F
       )
     }
 
@@ -467,7 +469,7 @@ des.print <- function(dat, group, create = "pdf", file, index = T, fsize = 11,
       my_doc <- flextable::body_add_flextable(my_doc, jet)
       print(my_doc, target = file)
     } else if (create == "R") {
-      show(jet)
+      return(jet)
     }
   } else {
     ##pdf, knitr, tex, custom

--- a/R/descr.R
+++ b/R/descr.R
@@ -435,7 +435,7 @@ descr <- function(dat, group, var.names, percent.vertical = T, data.names = T, n
       } else if (create == "R"){
         row.ab <- c()
         if ("n" %in% n.or.miss)
-          row.ab <- c(row.ab, "  - N")
+          row.ab <- c(row.ab, "    - N")
         if ("miss" %in% n.or.miss)
           row.ab <- c(row.ab, "   - Missing")
         if (!("n" %in% n.or.miss) & !("miss" %in% n.or.miss))


### PR DESCRIPTION
-"    -N" had 2 spaces instead of 4
-flextable headers did not display correctly because the string vectors containing the names were converted to factors
-create="R" now returns the flextable object instead of showing it, which is what should happen according to the description of ?des.print