### PR TITLE
Variablen mit ausschlißlich NA fix

### DIFF
--- a/R/descr.R
+++ b/R/descr.R
@@ -317,7 +317,7 @@ descr <- function(dat, group, var.names, percent.vertical = T, data.names = T, n
             pvalues_var[i] <- F
           }
         }
-        if (length(table(dat[[i]])) == 1) {
+        if (length(table(dat[[i]])) <= 1) {
           pvalues_var[i] = F
         } else {
           for (l in 1:length(table(dat[[i]]))) {
@@ -470,7 +470,7 @@ descr <- function(dat, group, var.names, percent.vertical = T, data.names = T, n
           if (n.vector[ -length(n.vector)][l] < groupsize)
             pvalues_var[i] <- F
         }
-        if (length(table(dat[[i]])) == 1) {
+        if (length(table(dat[[i]])) <= 1) {
           pvalues_var[i] = F
         } else {
           for (l in 1:length(table(dat[[i]]))) {


### PR DESCRIPTION
If length(table(dat)) == 0, there are only NA values and it does not make sense to calc pval. Also the "else" clause is skipped, which would throw an error.