### PR TITLE
I mistakenly assumed that the boschloo test is invariant under transp…

### DIFF
--- a/R/p.cat.R
+++ b/R/p.cat.R
@@ -86,7 +86,7 @@ p.cat <- function(x, group, paired = F, is.ordered = F, correct.cat = F, correct
         }
         else{
           test.name <- "Fisher_boschloo"
-          tl <- Exact::exact.test(table(x,group), method="boschloo", to.plot=F)
+          tl <- Exact::exact.test(table(group,x), method="boschloo", to.plot=F)
           pv <- tl$p.value
           test.value <- tl$statistic
         }


### PR DESCRIPTION
…osition of the contingency table. In our usecase, this seems to be wrong.

Arrangement of the tested contingency table was changed so that the groups are represented by rows and the responses are represented by columns now.