### PR TITLE
Bugfix for data that contains missings in the grouping variable and only one other variable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,5 @@ Imports:
 License: GPL
 LazyLoad: true
 LazyData: true
-RoxygenNote: 7.0.0
+RoxygenNote: 7.0.2
 Encoding: UTF-8
-  

--- a/R/descr.R
+++ b/R/descr.R
@@ -168,7 +168,7 @@ descr <- function(dat, group, var.names, percent.vertical = T, data.names = T, n
   }
   if (length(group.na.index) != 0) {
     warning(paste("Missing values in the group variable ( Observations: ", list(group.na.index), " )! Observations will be removed!"))
-    dat <- dat[-group.na.index, ]
+    dat <- dat[-group.na.index, , drop=FALSE]
     group <- group[-group.na.index]
   }
 

--- a/R/descr.R
+++ b/R/descr.R
@@ -661,3 +661,4 @@ descr <- function(dat, group, var.names, percent.vertical = T, data.names = T, n
   }
   return(list("descr" = ab1, "pos" = pos, "pos.pagebr" = pos.pagebr, "testings" = testings, "pvalues_var" = pvalues_var))
 }
+


### PR DESCRIPTION
Fixed bug where data.frame was unintentionally coerced to vector if it contains only 1 variable.